### PR TITLE
View/EditController: constructor options

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,7 @@
 {
-  "presets": [
-    "es2015"
-  ],
   "plugins": [
     "transform-function-bind",
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "transform-es2015-modules-commonjs"
   ]
 }

--- a/src/EditController.js
+++ b/src/EditController.js
@@ -20,8 +20,8 @@ import ViewController from './ViewController'
  */
 
 class EditController extends ViewController {
-  constructor() {
-    super()
+  constructor(options) {
+    super(options)
 
     let routePrefix = this.routePrefix
     router.route(routePrefix+"/create", ::this._create)

--- a/src/ViewController.js
+++ b/src/ViewController.js
@@ -32,8 +32,15 @@ import {storage, HasModels} from 'nxus-storage'
 
 
 class ViewController extends HasModels {
-  constructor() {
-    super()
+  constructor(options={}) {
+    if (!options.modelNames) {
+      options.modelNames = [options]
+    }
+    super(options)
+
+    this._modelIdentity = options.modelIdentity
+    this._prefix = options.prefix
+    this._displayName = options.displayName
 
     let routePrefix = this.routePrefix
     router.route(routePrefix, ::this._list)
@@ -48,16 +55,12 @@ class ViewController extends HasModels {
 
   // Parameters
   
-  modelNames() {
-    return [this.modelIdentity]
-  }
-
   get modelIdentity() {
-    return morph.toSnake(this.constructor.name)
+    return this._modelIdentity || morph.toSnake(this.constructor.name)
   }
 
   get prefix() {
-    return morph.toDashed(this.constructor.name)
+    return this._prefix || morph.toDashed(this.constructor.name)
   }
 
   get templatePrefix() {
@@ -73,7 +76,7 @@ class ViewController extends HasModels {
   }
 
   get displayName() {
-    return this.constructor.name
+    return this._displayName || this.constructor.name
   }
 
   get instanceTitleField() {


### PR DESCRIPTION
Removes the parameter getter methods in favor of constructor options. Drops all babel es2015 support other than modules import/export so that node 6.5 can provide class implementation to allow new.target to work.