### PR TITLE
Refactor View/EditController for related field editing

### DIFF
--- a/src/EditController.js
+++ b/src/EditController.js
@@ -153,7 +153,7 @@ class EditController extends ViewController {
       attrs.forEach((attr) => {
         if(attr.type == 'boolean') values[attr.name] = (typeof values[attr.name] != 'undefined' && values[attr.name])
         if(attr.type == 'array' && _.isString(values[attr.name])) {
-          values[attr.name] = values[attr.name].split(',')
+          values[attr.name] = values[attr.name].split('\r\n')
         }
         try {
           if(attr.type == 'json' || attr.type == 'mixed') values[attr.name] = JSON.parse(values[attr.name])

--- a/src/ViewController.js
+++ b/src/ViewController.js
@@ -137,8 +137,10 @@ class ViewController extends HasModels {
   _list(req, res) {
     Promise.all([
       this.list(req, res, this._find(req)),
-      this.defaultContext(req)
-    ]).spread((context, defaultContext) => {
+      this.defaultContext(req),
+      this.model.count()
+    ]).spread((context, defaultContext, count) => {
+      defaultContext.pagination.count = count
       context = Object.assign(defaultContext, context)
       return templater.render(this.templatePrefix+'-list', context).then(::res.send)
     })

--- a/src/templates/form-inputs/web-form-input-array.ejs
+++ b/src/templates/form-inputs/web-form-input-array.ejs
@@ -1,6 +1,6 @@
 <div class="form-group">
     <label class="col-sm-3 to-right" for="control_<%= name %>"><%= label %> (array)</label>
     <div class="col-sm-7">
-        <textarea rows="10" style="min-height: 100px;" id="control_<%= name %>" class="form-control" placeholder="Enter <%= label %> as list of quoted comma-separated values" name="<%= name %>"><%= JSON.stringify(value, null, 2) %></textarea>
+        <textarea rows="10" style="min-height: 100px;" id="control_<%= name %>" class="form-control" placeholder="Enter <%= label %> as list one item per line" name="<%= name %>"><%= value && value.length ? value.join("\n") : value %></textarea>
     </div>
 </div>

--- a/src/templates/form-inputs/web-form-input-related-many.ejs
+++ b/src/templates/form-inputs/web-form-input-related-many.ejs
@@ -1,10 +1,10 @@
 <div class="form-group">
     <label class="col-sm-3 to-right" for="control_<%= name %>"><%= label %></label>
     <div class="col-sm-7">
-      <select id="control_<%= name %>" class="form-control" name="<%= name %>">
+      <select multiple id="control_<%= name %>" class="form-control" name="<%= name %>" size="10">
       <% if(typeof instances != "undefined") { %>
         <% instances.forEach(function(i) { %>
-          <option value="<%=i.id%>" <% if (value == i.id) { %>selected<% } %>><%= i.displayName() %></option>
+          <option value="<%=i.id%>" <% if (_.any(value, function(x) {return x.id==i.id})) { %>selected<% } %>><%= i.displayName() %></option>
         <% }) %>
       <% } %>
       </select>

--- a/src/templates/web-controller-paginator.ejs
+++ b/src/templates/web-controller-paginator.ejs
@@ -2,10 +2,11 @@
 <% var base = '/' %>
 <% } %>
 <% var page = pagination.currentPage %>
-<% var totalPages = Math.ceil(objects.length/pagination.itemsPerPage) %>
+<% var totalPages = Math.ceil(pagination.count/pagination.itemsPerPage) %>
 <% var previousPage = page > 1 ? page-1 : null %>
 <% var nextPage = page < totalPages ? page+1 : null %>
 <% var pages = _.range(page < 3 ? 1 : page-2, page > totalPages-3 ? totalPages+1 : (page < 3 ? 6 : page+3)) %>
+
 <% if(pages.length > 1) { %> 
 <ul class="pagination">
   <% if(previousPage) { %>


### PR DESCRIPTION
Restores the old admin functionality of allowing related fields to be selected when editing. Additionally supports M2M related fields for this.

This is a breaking change to the Controller API because `_modelAttributes` needs to be promised now, which means `defaultContext` needs to be promised, and `convertValues` return signature is additionally changed to return values that need to be set explicitly for relations rather than in the update/create call (grr WL). Please shout if these will break a lot of 4.0 code I can't think of, we could of course layer this related stuff in separately in several places, but I think having `defaultContext` be promised at least is a better 4.0 API anyways.

cc @mjreich @ScottMaxson 