### PR TITLE
Allow the nav template to be overridden and reuse existing menus

### DIFF
--- a/src/modules/web-nav/index.js
+++ b/src/modules/web-nav/index.js
@@ -26,7 +26,6 @@ class Nav extends NxusModule {
       options.subMenu = this._createMenu(options.subMenu)
     }
     let existing = this._menus[menu].filter((x) => {return x.label == label})
-    if (menu == 'admin-sidebar') console.log(existing, label, this._menus[menu])
     if (!existing.length) {
       this._menus[menu].push({label, link, ...options})
     }

--- a/src/modules/web-nav/index.js
+++ b/src/modules/web-nav/index.js
@@ -24,8 +24,12 @@ class Nav extends NxusModule {
     menu = this._createMenu(menu)
     if(options.subMenu) {
       options.subMenu = this._createMenu(options.subMenu)
-    } 
-    this._menus[menu].push({label, link, ...options})
+    }
+    let existing = this._menus[menu].filter((x) => {return x.label == label})
+    if (menu == 'admin-sidebar') console.log(existing, label, this._menus[menu])
+    if (!existing.length) {
+      this._menus[menu].push({label, link, ...options})
+    }
   }
 
   /**
@@ -50,13 +54,14 @@ class Nav extends NxusModule {
 
   _createMenu(menu) {
     menu = morph.toDashed(menu)
-    this.log.debug('Registering Nav Menu', menu)
     if (!this._menus[menu]) {
+      this.log.debug('Registering Nav Menu', menu)
       this._menus[menu] = []
+      templater.templateFunction(menu, (opts) => {
+        var template = opts.subTemplate || 'nav-menu'
+        return templater.render(template, {menu, items: this.get(menu), ...opts})
+      })
     }
-    templater.templateFunction(menu, (opts) => {
-      return templater.render('nav-menu', {menu, items: this.get(menu), ...opts})
-    })
     return menu
   }
 }


### PR DESCRIPTION
This is in order to support some grouping for nxus-admin, so a given menu will be registered multiple times (to add additional sub-menus) and the template needs to be overridden just for admin (that is, from the template local call.)