### PR TITLE
Pass options thru to HasModels in MVCModule constructor

### DIFF
--- a/src/MVCModule.js
+++ b/src/MVCModule.js
@@ -25,11 +25,10 @@ const REGEX_FILE = /[^\/\~]$/;
 
 class MVCModule extends HasModels {
 
-  constructor() {
-    super()
+  constructor(options={}) {
+    super(options)
 
     this._controllers = []
-    this._model_identities = []
     
     templater.templateDir(this._dirName+"/templates/*.ejs", "page")
 


### PR DESCRIPTION
Changed so this can be used with options, eg "modelNames", in constructor so models will be built etc.
Also appears like the initialization of  `this._model_identities` isn't necessary?