### PR TITLE
Ensure MVC controllers are instantiated before load event

### DIFF
--- a/src/MVCModule.js
+++ b/src/MVCModule.js
@@ -32,7 +32,7 @@ class MVCModule extends HasModels {
     
     templater.templateDir(this._dirName+"/templates/*.ejs", "page")
 
-    this._loadControllers()
+    application.onceAfter('init', ::this._loadControllers)
   }
 
   _loadControllers() {
@@ -53,7 +53,7 @@ class MVCModule extends HasModels {
         this._controllers.push(new m())
       }
     })
-  }  
+  }
   
 }
 


### PR DESCRIPTION
Depending on other module load times, this would cause sub-controllers default/replace calls to all occur after load had begun.

Can you verify this branch fixes your app, Scott?