### PR TITLE
Fix nasty bug with model attributes mutating across requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nxus-web",
-  "version": "4.0.0-10",
+  "version": "4.0.0-11",
   "description": "Base theme, template, and MVC support for Nxus applications",
   "main": "lib",
   "scripts": {

--- a/src/ViewController.js
+++ b/src/ViewController.js
@@ -210,7 +210,7 @@ class ViewController extends HasModels {
     let attrs = _(model._attributes)
     .keys()
     .map((k, i) => {
-      let ret = model._attributes[k]
+      let ret = {...model._attributes[k]}
       ret.name = k
       if(titleField == null && i ==0) {
         ret.isTitle = true

--- a/src/templates/form-inputs/web-form-input-related.ejs
+++ b/src/templates/form-inputs/web-form-input-related.ejs
@@ -2,6 +2,7 @@
     <label class="col-sm-3 to-right" for="control_<%= name %>"><%= label %></label>
     <div class="col-sm-7">
       <select id="control_<%= name %>" class="form-control" name="<%= name %>">
+      <% if (value && value.id) { value = value.id } // handle populated values %>
       <% if(typeof instances != "undefined") { %>
         <% instances.forEach(function(i) { %>
           <option value="<%=i.id%>" <% if (value == i.id) { %>selected<% } %>><%= i.displayName() %></option>


### PR DESCRIPTION
This would manifest on random pages in the site when a model is queried, incorrectly expecting a populated field (like 'user') to be a hasMany rather than hasOne and throwing an uncaught exception in waterline toObject.

Traced it back to this mutable data error.