### PR TITLE
Controller Route customization

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "preversion": "npm test",
     "postversion": "npm run build-docs && git push && git push --tags",
     "test": "NODE_ENV=test mocha --compilers js:babel-core/register -R spec src/test/*.js src/modules/**/test/*.js",
-    "compile": "babel src --out-dir lib --ignore src/modules/web-theme-default/assets; cp -r src/modules/web-theme-default/assets lib/modules/web-theme-default/; cp -r src/modules/web-theme-default/partials lib/modules/web-theme-default/; cp -r src/modules/web-theme-default/layouts lib/modules/web-theme-default/; npm run copyTemplates",
+    "compile": "rm -r lib; babel src --out-dir lib --ignore src/modules/web-theme-default/assets; cp -r src/modules/web-theme-default/assets lib/modules/web-theme-default/; cp -r src/modules/web-theme-default/partials lib/modules/web-theme-default/; cp -r src/modules/web-theme-default/layouts lib/modules/web-theme-default/; npm run copyTemplates",
     "copyTemplates": "cp -r src/templates lib/; for each in `ls src/modules/`; do if [ -d src/modules/$each/templates ]; then cp -r src/modules/$each/templates lib/modules/$each; fi; done;",
     "prepublish": "npm run compile",
     "postpublish": "npm run build-docs && npm run publish-docs",

--- a/src/EditController.js
+++ b/src/EditController.js
@@ -24,7 +24,7 @@ import ViewController from './ViewController'
  */
 
 class EditController extends ViewController {
-  constructor(options) {
+  constructor(options={}) {
     super(options)
 
     let routePrefix = this.routePrefix

--- a/src/EditController.js
+++ b/src/EditController.js
@@ -45,6 +45,16 @@ class EditController extends ViewController {
     templater.default().template(__dirname+"/templates/web-controller-paginator.ejs")
   }
 
+  /** Replaces route parameters with values.
+   * @param {string} route route path
+   * @param {Object} params parameter replacements
+   * @returns {string} route path, with parameters replaced
+   */
+  static replaceRouteParams(route, params) {
+    _.each(params, (val, key) => { route = route.replace(":" + key, val) })
+    return route
+  }
+  
   /*
   * Override to modify the routes used for redirects, links.
   * Useful to replace extra route `:params` in `this.routePrefix`.

--- a/src/EditController.js
+++ b/src/EditController.js
@@ -11,6 +11,10 @@ import ViewController from './ViewController'
  * 
  * # Parameters
  *  See Controller docs
+ *  * `redirectAfterCreate` - path suffix to routePrefix after route
+ *  * `redirectAfterEdit` - path suffix to routePrefix after route
+ *  * `redirectAfterDelete` - path suffix to routePrefix after route
+ * 
  * 
  * # Implement Routes
  * 
@@ -41,6 +45,13 @@ class EditController extends ViewController {
     templater.default().template(__dirname+"/templates/web-controller-paginator.ejs")
   }
 
+  /*
+  * Override to modify the routes used for redirects, links.
+  * Useful to replace extra route `:params` in `this.routePrefix`.
+  * @param {Request} req The express req object
+  * @param {String} route The route to be updated
+  * @returns {String} The route to be used
+  */
   routeForRequest(req, route) {
     return route
   }

--- a/src/EditController.js
+++ b/src/EditController.js
@@ -31,7 +31,7 @@ class EditController extends ViewController {
     router.route("POST", routePrefix+"/delete/:id", ::this.remove)
 
     this.redirectAfterCreate = options.redirectAfterCreate || ""
-    this.redirectAfterEdit = options.redirectAfterEdit || "/create"
+    this.redirectAfterEdit = options.redirectAfterEdit || ""
     this.redirectAfterDelete = options.redirectAfterDelete || ""
     
     // Yes, these should be __dirname not local to the subclass

--- a/src/ViewController.js
+++ b/src/ViewController.js
@@ -66,7 +66,7 @@ class ViewController extends HasModels {
     this.ignoreFields = options.ignoreFields || ['id', 'createdAt', 'updatedAt']
     this.displayFields = options.displayFields || []
     this.listFields = options.listFields || []
-    this.instanceTitleField = options.instanceTitleField || this.displayFields.length > 0 ? this.displayFields[0] : null
+    this.instanceTitleField = options.instanceTitleField || (this.displayFields.length > 0 ? this.displayFields[0] : null)
     this.idField = options.idField || 'id'
 
     

--- a/src/ViewController.js
+++ b/src/ViewController.js
@@ -18,7 +18,7 @@ import {storage, HasModels} from 'nxus-storage'
  *  * `templatePrefix` - defaults to parent containing directory (module) + `prefix`, e.g. `mymodule-todo-item-`
  *  * `routePrefix` - defaults to '/'+`prefix`
  *  * `pageTemplate` - the layout to use to render the page
- *  * `populate` - relationships to populate on find
+ *  * `populate` - relationships to populate on find. Accepts a string, array, or array of [rel, options] arrays.
  *  * `displayName` - defaults to class name
  *  * `instanceTitleField` - defaults to first attribute
  *  * `paginationOptions` - object with `sortField`, `sortDirection`, and `itemsPerPage` keys.

--- a/src/ViewController.js
+++ b/src/ViewController.js
@@ -110,11 +110,9 @@ class ViewController extends HasModels {
       .sort(pageOptions.sortField + ' ' + pageOptions.sortDirection)
       .limit(pageOptions.itemsPerPage)
       .skip((pageOptions.currentPage-1)*pageOptions.itemsPerPage)
-    if (this.populate.length) {
-      for (let p of this.populate) {
-        if (!_.isArray(p)) p = [p]
-        find.populate.apply(find, p)
-      }
+    for (let p of this.populate) {
+      if (!_.isArray(p)) p = [p]
+      find.populate(...p)
     }
     return find
   }
@@ -123,11 +121,9 @@ class ViewController extends HasModels {
     let query = {}
     query[this.idField] = req.params.id
     let find =  this.model.findOne(query)
-    if (this.populate.length) {
-      for (let p of this.populate) {
-        if (!_.isArray(p)) p = [p]
-        find.populate.apply(find, p)
-      }
+    for (let p of this.populate) {
+      if (!_.isArray(p)) p = [p]
+      find.populate(...p)
     }
     return find
   }

--- a/src/ViewController.js
+++ b/src/ViewController.js
@@ -52,7 +52,10 @@ class ViewController extends HasModels {
     this.prefix = options.prefix || morph.toDashed(new.target.name)
     this.templatePrefix = options.templatePrefix || this.prefix
     this.pageTemplate = options.pageTemplate || 'page'
-    this.populate = options.populate || null
+    this.populate = options.populate || []
+    if (!_.isArray(this.populate)) {
+      this.populate = [this.populate]
+    }
     this.routePrefix = options.routePrefix || '/' + this.prefix
     this.displayName = options.displayName || new.target.name
     this.paginationOptions = options.paginationOptions || {
@@ -107,8 +110,11 @@ class ViewController extends HasModels {
       .sort(pageOptions.sortField + ' ' + pageOptions.sortDirection)
       .limit(pageOptions.itemsPerPage)
       .skip((pageOptions.currentPage-1)*pageOptions.itemsPerPage)
-    if (this.populate) {
-      find.populate(this.populate)
+    if (this.populate.length) {
+      for (let p of this.populate) {
+        if (!_.isArray(p)) p = [p]
+        find.populate.apply(find, p)
+      }
     }
     return find
   }

--- a/src/ViewController.js
+++ b/src/ViewController.js
@@ -123,8 +123,11 @@ class ViewController extends HasModels {
     let query = {}
     query[this.idField] = req.params.id
     let find =  this.model.findOne(query)
-    if (this.populate) {
-      find.populate(this.populate)
+    if (this.populate.length) {
+      for (let p of this.populate) {
+        if (!_.isArray(p)) p = [p]
+        find.populate.apply(find, p)
+      }
     }
     return find
   }

--- a/src/modules/web-theme-default/partials/flash.ejs
+++ b/src/modules/web-theme-default/partials/flash.ejs
@@ -1,4 +1,4 @@
-                <% if(typeof req != 'undefined' && req.flash != 'undefined') { %>
+                <% if(req && req.flash) { %>
                 <% var messages = req.flash(); %>
                 <% if (messages.error && messages.error.length > 0) { %>
                 <% messages.error.forEach(function(flash) { %>


### PR DESCRIPTION
Provide options and a no-op method for modifying routes used by the controller. I needed this for a `routePrefix` that included a parent `:param`, and to have a wizard-ish simple create form that redirects on success to the edit form with more functionality rather than back to list.

Also expands `populate` option to allow both multiple populates, and populate options, with an array value or an array of 2-arrays.