### PR TITLE
Allow filtering of related instances per-request

### DIFF
--- a/src/EditController.js
+++ b/src/EditController.js
@@ -86,7 +86,7 @@ class EditController extends ViewController {
   _create(req, res) {
     return Promise.all([
       this.create(req, res, {}),
-      this.defaultContext(req)
+      this.defaultContext(req, true)
     ]).spread((context, defaultContext) => {
       context = Object.assign(defaultContext, context)
       return templater.render(this.templatePrefix+"-create", context).then(::res.send)


### PR DESCRIPTION
(Also changed `_modelAttributes` to return attrs in displayFields order if specified.)

Using this on MwM to filter related objects to those belonging to the request user.