### PR TITLE
Fixed guard clause for flash.ejs partial invoked with no request context.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nxus-web",
-  "version": "4.0.0-13",
+  "version": "4.0.0-14",
   "description": "Base theme, template, and MVC support for Nxus applications",
   "main": "lib",
   "scripts": {

--- a/src/modules/web-theme-default/partials/flash.ejs
+++ b/src/modules/web-theme-default/partials/flash.ejs
@@ -1,4 +1,4 @@
-                <% if(req && req.flash) { %>
+                <% if((typeof req !== 'undefined') && req.flash) { %>
                 <% var messages = req.flash(); %>
                 <% if (messages.error && messages.error.length > 0) { %>
                 <% messages.error.forEach(function(flash) { %>


### PR DESCRIPTION
Previous code fails with `ReferenceError` if `req` is undeclared. This should now work if either undeclared or undefined.
