### PR TITLE
Fixed cut-and-paste error in web-form-input-checkbox.ejs.

### DIFF
--- a/src/templates/form-inputs/web-form-input-checkbox.ejs
+++ b/src/templates/form-inputs/web-form-input-checkbox.ejs
@@ -1,6 +1,6 @@
      <div class="form-group">
-        <label class="col-sm-3 to-right" for="phone"><%= label %>?</label>
+        <label class="col-sm-3 to-right" for="control_<%= name %>"><%= label %>?</label>
         <div class="col-sm-7">
-            <input type="checkbox" id="<%= name %>" class="" <%= value ? 'checked="checked"' : '' %> name="<%= name %>">
+            <input type="checkbox" id="control_<%= name %>" class="" <%= value ? 'checked="checked"' : '' %> name="<%= name %>">
         </div>
     </div>


### PR DESCRIPTION
Changed the `<label>` `for` linkage to match the other input elements.