### PR TITLE
Datatables support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,7 @@
   "plugins": [
     "transform-function-bind",
     "transform-object-rest-spread",
+    "transform-async-to-generator",
     "transform-es2015-modules-commonjs"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nxus-web",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "Base theme, template, and MVC support for Nxus applications",
   "main": "lib",
   "scripts": {

--- a/src/DataTablesMixin.js
+++ b/src/DataTablesMixin.js
@@ -8,6 +8,10 @@ import Promise from 'bluebird'
  *
  * Supports either client-side data (overriding normal pagination queries) or server-side processing (providing an ajax endpoint compatible with datatables API).
  *
+ * Options:
+ *  * `useDataTablesAjax` - (false) whether server-side ajax should be used to populate, page, and query the data
+ *  * `useDataTablesCSS` - (true) some themes already include datatables support, if so set this to false
+ *
  * Client-side processing is the default:
  *
  * ```
@@ -35,6 +39,11 @@ import Promise from 'bluebird'
 let DataTablesMixin = (superclass) => class extends(superclass) {
   constructor(opts={}) {
     super(opts)
+
+    this.useDataTablesCSS = true
+    if (opts.useDataTablesCSS !== undefined) {
+      this.useDataTablesCSS = opts.useDataTablesCSS
+    }
     
     templater.on(`renderContext.${this.templatePrefix}-list`, () => {
       return {
@@ -61,6 +70,7 @@ let DataTablesMixin = (superclass) => class extends(superclass) {
   defaultContext() {
     return super.defaultContext(...arguments).then((context) => {
       context.datatableAjaxRoute = this._datatableAjaxRoute
+      context.useDataTablesCSS = this.useDataTablesCSS
       return context
     })
   }

--- a/src/DataTablesMixin.js
+++ b/src/DataTablesMixin.js
@@ -40,6 +40,7 @@ let DataTablesMixin = (superclass) => class extends(superclass) {
   constructor(opts={}) {
     super(opts)
 
+    this.useDataTablesAjax = opts.useDataTablesAjax || false
     this.useDataTablesCSS = true
     if (opts.useDataTablesCSS !== undefined) {
       this.useDataTablesCSS = opts.useDataTablesCSS
@@ -61,7 +62,7 @@ let DataTablesMixin = (superclass) => class extends(superclass) {
       clientjs.includeScript(this.templatePrefix+"-list", __dirname+"/templates/datatables-enable.js")
     }
 
-    if (opts.useDataTablesAjax) {
+    if (this.useDataTablesAjax) {
       this._datatableAjaxRoute = this.routePrefix+'/dt-query'
       router.route('get', this._datatableAjaxRoute, ::this._datatableAjax)
     }

--- a/src/DataTablesMixin.js
+++ b/src/DataTablesMixin.js
@@ -107,8 +107,8 @@ let DataTablesMixin = (superclass) => class extends(superclass) {
 
     let acts = await actions.getActions(this.templatePrefix+"-list")
     objects = await Promise.map(objects, async (x) => {
-      let r = {id: x[this.idField], actions: "<i>Hi</i>"}
-      r.actions = await templater.render('actions-icons', {actions: acts.instance, makeActionUrl: (l) => {this.routePrefix + l + r.id}})
+      let r = {id: x[this.idField], actions: ""}
+      r.actions = await templater.render('actions-icons', {actions: acts.instance, makeActionUrl: (l) => {return this.routePrefix + l + r.id}})
       for (let k of fields) {
         r[k] = x[k]
       }

--- a/src/DataTablesMixin.js
+++ b/src/DataTablesMixin.js
@@ -1,0 +1,116 @@
+import {router} from 'nxus-router'
+import {templater} from 'nxus-templater'
+import {actions} from './modules/web-actions'
+import Promise from 'bluebird'
+
+/**
+ * A mixin class for ViewController or subclasses to support jQuery DataTables (https://datatables.net)
+ *
+ * Supports either client-side data (overriding normal pagination queries) or server-side processing (providing an ajax endpoint compatible with datatables API).
+ *
+ * Client-side processing is the default:
+ *
+ * ```
+ *   import {DataTablesMixin, EditController} from 'nxus-web
+ *   class MyView extends DataTablesMixin(EditController) {
+ *      // usual EditController options like model, displayFields
+ *   }
+ * ```
+ *
+ * Set the `useDataTablesAjax` option to true for large datasets or server-side search logic etc.
+ *
+ * ```
+ *   import {DataTablesMixin, EditController} from 'nxus-web
+ *   class MyView extends DataTablesMixin(EditController) {
+ *       constructor(options={}) {
+ *          // usual EditController options like model, displayFields
+ *          options.useDataTablesAjax = true
+ *          super(options)
+ *      }
+ *   }
+ * ```
+ *
+ */
+
+let DataTablesMixin = (superclass) => class extends(superclass) {
+  constructor(opts={}) {
+    super(opts)
+    
+    templater.on(`renderContext.${this.templatePrefix}-list`, () => {
+      return {
+        scripts: ['//cdn.datatables.net/1.10.16/js/jquery.dataTables.js']
+      }
+    })
+    templater.replace().template(__dirname+"/templates/web-controller-datatables-list.ejs", this.pageTemplate, this.templatePrefix+'-list')
+
+    try {
+      var clientjs = require('nxus-clientjs').clientjs
+    } catch (e) {
+      this.log.error("nxus-web DataTablesMixin: nxus-clientjs not installed\n\nYou will need to include nxus-web/lib/templates/datatables-enable.js manually in your template output after jquery")
+    }
+    if (clientjs){
+      clientjs.includeScript(this.templatePrefix+"-list", __dirname+"/templates/datatables-enable.js")
+    }
+
+    if (opts.useDataTablesAjax) {
+      this._datatableAjaxRoute = this.routePrefix+'/dt-query'
+      router.route('get', this._datatableAjaxRoute, ::this._datatableAjax)
+    }
+  }
+
+  defaultContext() {
+    return super.defaultContext(...arguments).then((context) => {
+      context.datatableAjaxRoute = this._datatableAjaxRoute
+      return context
+    })
+  }
+
+  _paginationState(req) {
+    let ret = super._paginationState(req)
+    if (!this.useDataTablesAjax) {
+      ret.itemsPerPage = 0
+      ret.currentPage = 1
+    }
+    return ret
+  }
+  
+  /* Handle datatables server-side processing ajax requests */
+  async _datatableAjax(req, res) {
+    let fields = this.listFields.length > 0 ? this.listFields : this.displayFields
+
+    // remap datatables query params to ViewController fields
+    req.query.items = parseInt(req.query.length)
+    req.query.page = (parseInt(req.query.start)/req.query.items) + 1
+    req.query.sort = fields[parseInt(req.query.order.column)]
+    req.query.dir = req.query.order.dir
+    req.query.search = req.query.search.value
+
+    let objects = await this._find(req)
+
+    let count = await this._count({query: {}})
+    let countFiltered = count
+    if (req.query.search) {
+      countFiltered = await this._count(req)
+    }
+    
+
+    let acts = await actions.getActions(this.templatePrefix+"-list")
+    objects = await Promise.map(objects, async (x) => {
+      let r = {id: x[this.idField], actions: "<i>Hi</i>"}
+      r.actions = await templater.render('actions-icons', {actions: acts.instance, makeActionUrl: (l) => {this.routePrefix + l + r.id}})
+      for (let k of fields) {
+        r[k] = x[k]
+      }
+      return r
+    })
+    res.send({
+      data: objects,
+      draw: parseInt(req.query.draw),
+      recordsTotal: count,
+      recordsFiltered: countFiltered
+    })
+  }
+
+}
+
+export default DataTablesMixin

--- a/src/MVCModule.js
+++ b/src/MVCModule.js
@@ -29,8 +29,9 @@ class MVCModule extends HasModels {
     super(options)
 
     this._controllers = []
+    this._pageTemplate = options.pageTemplate || "page"
     
-    templater.templateDir(this._dirName+"/templates/*.ejs", "page")
+    templater.templateDir(this._dirName+"/templates/*.ejs", this._pageTemplate)
 
     application.onceAfter('init', ::this._loadControllers)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import {templater} from 'nxus-templater'
 import MVCModule from './MVCModule'
 import ViewController from './ViewController'
 import EditController from './EditController'
+import DataTablesMixin from './DataTablesMixin'
 
 import {default as Nav, nav} from './modules/web-nav'
 import {default as Actions, actions} from './modules/web-actions'
@@ -21,6 +22,7 @@ let web = Web.getProxy()
 export {
   Web as default, web,
   MVCModule, ViewController, EditController,
+  DataTablesMixin,
   nav, Nav,
   actions, Actions
 }

--- a/src/modules/web-actions/index.js
+++ b/src/modules/web-actions/index.js
@@ -7,6 +7,9 @@ import _ from 'underscore'
  * Example adding a link button to the template 'template-name':
  * ```actions.add('template-name', 'Label', '/link' {icon: 'fa fa-plus'})```
  * 
+ * Retrieving actions for use (normally not needed, automatically added to template context as 'actions)
+ * ```actions.getActions('template-name')```
+ * 
  * You may additionally group actions together by providing a 'group' key to the options object. 
  *
  * # Templates
@@ -63,6 +66,15 @@ class WebActions extends NxusModule {
     })
   }
 
+  /*
+   * Returns actions for a given template
+   * @param {String} template
+   * @returns {Object} Action objects grouped by optional group names
+   */
+  getActions(template) {
+    return this._getActions(template)
+  }
+  
   _getActions(template) {
     let actions = this._actions[template]
     return _.groupBy(actions, 'group')

--- a/src/templates/datatables-enable.js
+++ b/src/templates/datatables-enable.js
@@ -1,0 +1,5 @@
+ $(document).ready(function() {
+     $('.datatable').DataTable({
+         
+     })
+ })

--- a/src/templates/web-controller-datatables-list.ejs
+++ b/src/templates/web-controller-datatables-list.ejs
@@ -1,4 +1,6 @@
-<link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.16/css/jquery.dataTables.css">
+<% if (useDataTablesCSS) { %>
+  <link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.16/css/jquery.dataTables.css">
+<% } %>
 
 <% if (typeof actions != 'undefined') { %>
   <%- render("actions-buttons", {actions: actions.default, makeActionUrl: function(link) {return base + link }}) %>

--- a/src/templates/web-controller-datatables-list.ejs
+++ b/src/templates/web-controller-datatables-list.ejs
@@ -1,0 +1,46 @@
+<link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.16/css/jquery.dataTables.css">
+
+<% if (typeof actions != 'undefined') { %>
+  <%- render("actions-buttons", {actions: actions.default, makeActionUrl: function(link) {return base + link }}) %>
+<% } %>
+<p></p>
+<% if (datatableAjaxRoute) { %>
+  <table class="datatable table table-striped" data-ajax="<%= datatableAjaxRoute %>"
+         data-page-length="<%= pagination.itemsPerPage %>" data-server-side="true">
+<% } else { %>
+    <table class="datatable table table-striped">
+<% } %>
+  <thead>
+    <tr>
+      <% attributes.forEach(function(attr) { %>
+        <th data-data="<%=attr.name%>"><%= attr.label %>
+        </th>
+      <% }) %>
+      <% if (typeof actions != "undefined" && actions.instance) { %>
+        <th data-data="actions" data-orderable='false'></th>
+      <% } %>
+    </tr>
+  </thead>
+  <tbody>
+    <% objects.forEach(function(u) { %>
+      <tr>
+        <% attributes.forEach(function(attr) { %>
+          <% if(attr.isTitle) { %>
+            <td><a href="<%=instanceUrl%>/<%=u[idField]%>"><%if (u[attr.name]) { %><%=u[attr.name]%><% } else { %>[empty]<%}%></a></td>
+          <% } else if (attr.type == 'password') { %> <% return %>
+        <% } else if (attr.type == 'boolean') { %>
+        <td><%- u[attr.name] ? '<i class="fa fa-check"></i>' : '' %></td>
+    <% } else { %>
+        <td><%= u[attr.name] %></td>
+    <% } %>
+          <% }) %>
+          <% if (typeof actions != "undefined" && actions.instance) { %>
+            <td  class="bold">
+              <%- render("actions-icons", {actions: actions.instance, makeActionUrl: function(link) { return base + link + u[idField]}}) %>
+            </td>
+          <% } %>
+      </tr>
+      <% }) %>
+  </tbody>   
+</table>
+

--- a/src/test/DataTablesMixin.js
+++ b/src/test/DataTablesMixin.js
@@ -1,0 +1,26 @@
+import ViewController from '../ViewController'
+import DataTablesMixin from '../DataTablesMixin'
+
+describe("DataTablesMixin", () => {
+  
+  it("should not be null", () => {
+    DataTablesMixin.should.not.be.null
+  })
+
+  describe("Subclassing", () => {
+
+    class DTThing extends DataTablesMixin(ViewController) {
+        
+    }
+
+    it("should nothave datatables ajax route by default", () => {
+      let t = new DTThing()
+      t.should.not.have.property('_datatableAjaxRoute')
+    })
+    it("should have datatables ajax route if true", () => {
+      let t = new DTThing({useDataTablesAjax: true})
+      t._datatableAjaxRoute.should.equal('/dt-thing/dt-query')
+    })
+  })
+
+})

--- a/src/test/ViewController.js
+++ b/src/test/ViewController.js
@@ -30,6 +30,7 @@ describe("ViewController", () => {
       router.provide.calledWith("route", "/thing-one/view/:id").should.be.true
     })
 
+
     class ThingTwo extends ViewController {
 
     }
@@ -52,4 +53,59 @@ describe("ViewController", () => {
       t._modelNames.should.have.property('two')
     })
   })
+
+
+  describe("pagination", () => {
+    class Paged extends ViewController {
+        
+    }
+
+    it("should have defaults", () => {
+      let t = new Paged()
+      t.should.have.property('paginationOptions')
+      t.paginationOptions.should.have.property('sortField', 'updatedAt')
+      t.paginationOptions.should.have.property('sortDirection', 'ASC')
+      t.paginationOptions.should.have.property('itemsPerPage', 20)
+    })
+    it("should get from req.query", () => {
+      let t = new Paged()
+      let p = t._paginationState({
+        query: {
+          page: 2,
+          items: 10,
+          sort: 'name',
+          dir: 'DESC'
+        }
+      })
+      p.should.have.property('sortField', 'name')
+      p.should.have.property('sortDirection', 'DESC')
+      p.should.have.property('itemsPerPage', 10)
+      p.should.have.property('currentPage', 2)
+    })
+    
+  })
+
+  describe("Search Query", () => {
+    class Query extends ViewController {
+        
+    }
+
+    it("should find all by default", () => {
+      let t = new Query()
+      let q = t._filterQuery({query: {}})
+      q.should.eql({})
+    })
+    it("should get from req.query to searchFields", () => {
+      let t = new Query({searchFields: ['name', 'email'], displayFields: []})
+      let q = t._filterQuery({query: {search: 'bob'}})
+      q.should.eql({or: [{name: {contains: 'bob'}}, {email: {contains: 'bob'}}]})
+    })
+    it("should fallback to displayFields", () => {
+      let t = new Query({displayFields: ['name']})
+      let q = t._filterQuery({query: {search: 'bob'}})
+      q.should.eql({or: [{name: {contains: 'bob'}}]})
+    })
+    
+  })
+  
 })


### PR DESCRIPTION
Adds a `DataTablesMixin` helper to wrap ViewController/EditController/AdminController and use datatables for the list view. Supports either all-data-at-once (client-side datatables, default) or the server-side version of datatables that relies on ajax to perform all searching, sorting, and pagination.