### PR TITLE
Fix to save for create and edit routes.

### DIFF
--- a/src/EditController.js
+++ b/src/EditController.js
@@ -192,7 +192,6 @@ class EditController extends ViewController {
         inst[k].add(i)
       }
     }
-    req.object = inst
     return inst.save()
   }
 
@@ -205,7 +204,18 @@ class EditController extends ViewController {
   async _doRemove(id) {
     return this.model.destroy(id)
   }
-  
+
+   /**
+   * Implement object save for create and edit routes.
+   *
+   * As a side-effect, it adds an `object` property to the request
+   * object that contains the created or modified object. This is for
+   * the benefit of the `routeForRequest()` method, which may find it
+   * useful creating the redirect route.
+   *
+   * @param {Request}  req The express request object
+   * @param {Response} res The express response object
+   */
   async save(req, res) {
     let id
     try {
@@ -219,6 +229,7 @@ class EditController extends ViewController {
         inst = await this._doRelatedUpdate(inst, related)
       }
 
+      req.object = inst
       req.flash('info', this.displayName + " saved")
     } catch(e) {
       this.log.error(e.toString())

--- a/src/EditController.js
+++ b/src/EditController.js
@@ -192,7 +192,8 @@ class EditController extends ViewController {
         inst[k].add(i)
       }
     }
-    return inst.save()
+    await inst.save()
+    return inst
   }
 
   

--- a/src/EditController.js
+++ b/src/EditController.js
@@ -74,9 +74,13 @@ class EditController extends ViewController {
   * Useful to replace extra route `:params` in `this.routePrefix`.
   * @param {Request} req The express req object
   * @param {String} route The route to be updated
+  * @param {Object} the model instance that has been saved (from create
+  *   or edit actions) or deleted; undefined when route is for the
+  *   default context; may also be undefined if the save or delete
+  *   failed
   * @returns {String} The route to be used
   */
-  routeForRequest(req, route) {
+  routeForRequest(req, route, inst) {
     return route
   }
   
@@ -209,20 +213,15 @@ class EditController extends ViewController {
    /**
    * Implement object save for create and edit routes.
    *
-   * As a side-effect, it adds an `object` property to the request
-   * object that contains the created or modified object. This is for
-   * the benefit of the `routeForRequest()` method, which may find it
-   * useful creating the redirect route.
-   *
    * @param {Request}  req The express request object
    * @param {Response} res The express response object
    */
   async save(req, res) {
-    let id
+    let id, inst
     try {
       let [values, related] = await this.convertValues(req.body)
       id = values[this.idField]
-      let inst = await (id
+      inst = await (id
             ? this._doUpdate(id, values)
             : this._doCreate(values))
 
@@ -230,7 +229,6 @@ class EditController extends ViewController {
         inst = await this._doRelatedUpdate(inst, related)
       }
 
-      req.object = inst
       req.flash('info', this.displayName + " saved")
     } catch(e) {
       this.log.error(e.toString())
@@ -239,7 +237,8 @@ class EditController extends ViewController {
     
     if (this.redirect) {
       res.redirect(this.routeForRequest(req,
-          this.routePrefix + (id ? this.redirectAfterEdit : this.redirectAfterCreate)))
+          this.routePrefix + (id ? this.redirectAfterEdit : this.redirectAfterCreate),
+          inst))
     }
   }
 
@@ -267,15 +266,18 @@ class EditController extends ViewController {
   }
   
   async remove(req, res) {
+    let inst
     try {
-      let inst = await this._doRemove(req.params.id)
+      inst = await this._doRemove(req.params.id)
       req.flash('info', this.displayName + " deleted")
     } catch(e) {
       this.log.error(e)
       req.flash('error', "Error deleting "+this.displayName+": "+e)
     }
     if (this.redirect) {
-      res.redirect(this.routeForRequest(req, this.routePrefix + this.redirectAfterDelete))
+      res.redirect(this.routeForRequest(req,
+          this.routePrefix + this.redirectAfterDelete,
+          inst))
     }
   }  
 }

--- a/src/EditController.js
+++ b/src/EditController.js
@@ -74,9 +74,9 @@ class EditController extends ViewController {
   * Useful to replace extra route `:params` in `this.routePrefix`.
   * @param {Request} req The express req object
   * @param {String} route The route to be updated
-  * @param {Object} the model instance that has been saved (from create
-  *   or edit actions) or deleted; undefined when route is for the
-  *   default context; may also be undefined if the save or delete
+  * @param {Object} inst the model instance that has been saved (from
+  *   create or edit actions) or deleted; undefined when route is for
+  *   the default context; may also be undefined if the save or delete
   *   failed
   * @returns {String} The route to be used
   */


### PR DESCRIPTION
Moved the code that added the saved object to the request context from the `_doRelatedUpdate()` method (which has no reference to the request context) to the `save()` method (which probably makes more sense anyway). Added some documentation for this obscure side-effect.