### PR TITLE
Fixed error in EditController save() method.

### DIFF
--- a/src/EditController.js
+++ b/src/EditController.js
@@ -221,6 +221,7 @@ class EditController extends ViewController {
     try {
       let [values, related] = await this.convertValues(req.body)
       id = values[this.idField]
+      delete values[this.idField]
       inst = await (id
             ? this._doUpdate(id, values)
             : this._doCreate(values))


### PR DESCRIPTION
When creating a new entity, Waterline gets upset if the body object includes an empty id property, so added code to remove it.