### PR TITLE
Fix to EditController _doUpdate() method.

### DIFF
--- a/src/EditController.js
+++ b/src/EditController.js
@@ -159,7 +159,7 @@ class EditController extends ViewController {
    * @returns {object} The updated instance
    */
   async _doUpdate(id, values) {
-    return this.model.update(values[this.idField], values).then((is) => {return is[0]})
+    return this.model.update(id, values).then((is) => {return is[0]})
   }
 
    /**


### PR DESCRIPTION
The method picks the `id` property from the `values` parameter, rather than using the `id` parameter. If there is no id field in `values`, the update gets performed with an empty selector (so it updates _all_ records).