### PR TITLE
Tweaks for datatables mixin

### DIFF
--- a/src/modules/web-theme-default/assets/css/sb-admin-2.css
+++ b/src/modules/web-theme-default/assets/css/sb-admin-2.css
@@ -234,7 +234,7 @@ body {
     position: relative;
     clear: both;
 }
-
+/*
 table.dataTable thead .sorting,
 table.dataTable thead .sorting_asc,
 table.dataTable thead .sorting_desc,
@@ -261,7 +261,7 @@ table.dataTable thead .sorting:after {
     font-family: fontawesome;
     color: rgba(50,50,50,.5);
 }
-
+*/
 .btn-circle {
     width: 30px;
     height: 30px;


### PR DESCRIPTION
- Fix the double sort arrows on admin by removing those duplicated styles in sb-admin-2.css
- Extract the dt query modification and action link construction for use in subclasses.