### PR TITLE
Fix to PR #47.

### DIFF
--- a/src/EditController.js
+++ b/src/EditController.js
@@ -221,7 +221,7 @@ class EditController extends ViewController {
     try {
       let [values, related] = await this.convertValues(req.body)
       id = values[this.idField]
-      delete values[this.idField]
+      if (!id) delete values[this.idField]
       inst = await (id
             ? this._doUpdate(id, values)
             : this._doCreate(values))

--- a/src/test/EditController.js
+++ b/src/test/EditController.js
@@ -51,10 +51,12 @@ describe("EditController", () => {
       }
       
       async _doCreate(values) {
+        this.didCreateWithoutID = (values.id === undefined)
         this.didCreate = true
       }
 
       async _doUpdate(id, values) {
+        this.didUpdateWithID = (id !== undefined && id == values.id)
         this.didUpdate = true
       }
 
@@ -80,6 +82,7 @@ describe("EditController", () => {
     it("should call _doCreate on save without id", async () => {
       await t.save(req, res)
       t.didCreate.should.be.true
+      t.didCreateWithoutID.should.be.true
       req.flash.calledWith("info").should.be.true
       req.flash.calledWith("error").should.be.false
     })
@@ -88,6 +91,7 @@ describe("EditController", () => {
       req.body.id = 1
       await t.save(req, res)
       t.didUpdate.should.be.true
+      t.didUpdateWithID.should.be.true
       req.flash.calledWith("info").should.be.true
       req.flash.calledWith("error").should.be.false
     })


### PR DESCRIPTION
In the `EditController` `save()` method, can't safely delete the `id` field from the `values` object if it's non-null. In particular, there may be a `beforeUpdate` handler that expects it to be present (as in nxus-users `userModel.js`).